### PR TITLE
Add Build Argument for Docker Version Tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
     # - cron: '31 4 * * *'
   push:
     # branches: [ "main" ]
-    tags: [ 'v*.*.*' ]
+    tags: [ '*.*.*' ]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -78,3 +78,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args:
+            GIT_TAG=${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-publish.yml` file to enhance the Docker publishing workflow by broadening tag matching and adding build arguments for better versioning.

### Workflow improvements:

* Updated the `tags` configuration in the `push` event to match any version pattern (`*.*.*`), allowing for greater flexibility in triggering the workflow.
* Added a `build-args` section to the Docker build step, passing the `GIT_TAG` as a build argument for better integration of version information into Docker images.